### PR TITLE
double sign error fixed

### DIFF
--- a/3.restricted-mint-multisig/imports/multisig.leo
+++ b/3.restricted-mint-multisig/imports/multisig.leo
@@ -5,6 +5,12 @@ program multisig.aleo {
     mapping required_signatures: bool => u64;
     mapping proposals: Proposal => u64;
     mapping signers: address => bool;
+    mapping list_signed: Person => bool;
+
+    struct Person {
+        signer: address,
+        proposal: Proposal
+    }
 
     struct Proposal {
         program_address: address,
@@ -41,8 +47,10 @@ program multisig.aleo {
 
     finalize sign(caller: address, proposal: Proposal) {
         assert(Mapping::get(signers, caller));
+        Mapping::get(list_signed, Person { signer: caller, proposal: proposal });
         let signatures: u64 = Mapping::get_or_use(proposals, proposal, 0u64);
         Mapping::set(proposals, proposal, signatures + 1u64);
+        Mapping::set(list_signed, Person { signer: caller, proposal: proposal }, true);
     }
 
     transition add_signer(ticket_: ticket, new_signer: address) {


### PR DESCRIPTION
```
    mapping list_signed: Person => bool;

    struct Person {
        signer: address,
        proposal: Proposal
    }
    
    




    finalize sign(caller: address, proposal: Proposal) {
        assert(Mapping::get(signers, caller));
        Mapping::get(list_signed, Person { signer: caller, proposal: proposal });
        let signatures: u64 = Mapping::get_or_use(proposals, proposal, 0u64);
        Mapping::set(proposals, proposal, signatures + 1u64);
        Mapping::set(list_signed, Person { signer: caller, proposal: proposal }, true);
    }
```